### PR TITLE
Send proper outbound cookie header

### DIFF
--- a/lib/cookies.js
+++ b/lib/cookies.js
@@ -196,7 +196,7 @@ CookieJar.prototype.getAsHeader = function(domain, path, callback) {
         }
     })
     .map(function(cookie) {
-        return cookie.toString();
+        return cookie.toOutboundString();
     });
 
     if (callback instanceof Function) {
@@ -327,6 +327,14 @@ Cookie.fromString = function(string) {
         keyValParts.domain,
         keyValParts.hasOwnProperty("httponly")
     );
+};
+
+/**
+ * Outputs the cookie as a string, in the form of an outbound Cookie header
+ * @return {String}                  Stringified version of the cookie
+ */
+Cookie.prototype.toOutboundString = function() {
+    return this.name + "=" + this.value;
 };
 
 /**

--- a/lib/crawler.js
+++ b/lib/crawler.js
@@ -552,7 +552,7 @@ Crawler.prototype.getRequestOptions = function(queueItem) {
     // send/accept cookies
     if (crawler.acceptCookies && crawler.cookies.getAsHeader()) {
         requestOptions.headers.cookie =
-            crawler.cookies.getAsHeader(queueItem.host, queueItem.path);
+            crawler.cookies.getAsHeader(queueItem.host, queueItem.path).join("; ");
     }
 
     // Add auth headers if we need them

--- a/test/cookies.js
+++ b/test/cookies.js
@@ -193,10 +193,6 @@ describe("Cookies", function() {
 
                 parsedCookie2.name.should.equal(parsedCookie.name);
                 parsedCookie2.value.should.equal(parsedCookie.value);
-                parsedCookie2.expires.should.equal(parsedCookie.expires);
-                parsedCookie2.path.should.equal(parsedCookie.path);
-                parsedCookie2.domain.should.equal(parsedCookie.domain);
-                parsedCookie2.httponly.should.equal(parsedCookie.httponly);
             });
         });
 

--- a/test/testcrawl.js
+++ b/test/testcrawl.js
@@ -48,9 +48,28 @@ describe("Test Crawl", function() {
 
         crawler.on("fetchstart", function(queueItem, requestOptions) {
             if (i++) {
-                requestOptions.headers.cookie.should.be.an("array");
-                requestOptions.headers.cookie.should.have.lengthOf(1);
-                requestOptions.headers.cookie[0].should.match(/^thing=stuff/);
+                requestOptions.headers.cookie.should.be.a("string");
+                requestOptions.headers.cookie.should.match(/^thing=stuff$/);
+                done();
+            }
+        });
+
+        crawler.start();
+    });
+
+    it("should send multiple cookies properly", function(done) {
+        var crawler = makeCrawler("http://127.0.0.1:3000/"),
+            i = 0;
+
+        crawler.cookies.addFromHeaders([
+            "name1=value1",
+            "name2=value2",
+            "name3=value3"
+        ]);
+        crawler.on("fetchstart", function(queueItem, requestOptions) {
+            requestOptions.headers.cookie.should.be.a("string");
+            requestOptions.headers.cookie.should.match(/^(name\d=value\d; ){2}(name\d=value\d)$/);
+            if (i++ === 6) {
                 done();
             }
         });


### PR DESCRIPTION
## What this PR changes
`crawler.cookies.getAsHeader()` returns an array of strings with only the name/value pairs. The extra attributes of the cookie are not included. 
When added to `requestOptions.header.cookie` the array of cookies is combined into a single string to avoid bugs in Node versions less than 8.

## Rationale
Resolves issue #397 

Outbound cookies should only include name and value in the header.
In Node.js versions < 8 if `header.cookie` is set to an array, the values a concatenated with commas which is wrong [according to the specs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cookie). This was [fixed in Node 8](https://github.com/nodejs/node/pull/11259), but for compatibility if we join the cookie values and set `header.cookie` to a string it will always be right.