### PR TITLE
Fix wrong meta robots tag attribute

### DIFF
--- a/lib/crawler.js
+++ b/lib/crawler.js
@@ -903,7 +903,7 @@ Crawler.prototype.discoverResources = function(resourceText) {
     }
 
     if (crawler.respectRobotsTxt && /<meta(?:\s[^>]*)?\sname\s*=\s*["']?robots["']?[^>]*>/i.test(resourceText)) {
-        var robotsValue = /<meta(?:\s[^>]*)?\svalue\s*=\s*["']?([\w\s,]+)["']?[^>]*>/i.exec(resourceText.toLowerCase());
+        var robotsValue = /<meta(?:\s[^>]*)?\scontent\s*=\s*["']?([\w\s,]+)["']?[^>]*>/i.exec(resourceText.toLowerCase());
 
         if (Array.isArray(robotsValue) && /nofollow/i.test(robotsValue[1])) {
             return [];

--- a/test/discovery.js
+++ b/test/discovery.js
@@ -203,10 +203,10 @@ describe("Crawler link discovery", function() {
 
     it("should respect nofollow values in robots meta tags", function() {
 
-        discover("<meta name='robots' value='nofollow'><a href='/stage2'>Don't follow me!</a>")
+        discover("<meta name='robots' content='nofollow'><a href='/stage2'>Don't follow me!</a>")
             .should.eql([]);
 
-        discover("<meta name='robots' value='nofollow, noindex'><a href='/stage2'>Don't follow me!</a>")
+        discover("<meta name='robots' content='nofollow, noindex'><a href='/stage2'>Don't follow me!</a>")
             .should.eql([]);
     });
 });

--- a/test/lib/routes.js
+++ b/test/lib/routes.js
@@ -50,7 +50,7 @@ module.exports = {
     },
 
     "/nofollow": function(write) {
-        write(200, "<meta name='robots' value='nofollow'><a href='/stage7'>Don't go here!</a>");
+        write(200, "<meta name='robots' content='nofollow'><a href='/stage7'>Don't go here!</a>");
     },
 
     "/cookie": function(write) {


### PR DESCRIPTION
## What this PR changes

A wrong attribute was used for the meta robots tag:

wrong: ```<meta name='robots' value='nofollow'>```
good: ```<meta name='robots' content='nofollow'>```

