### PR TITLE
Basic and X509 Auth, Proxy fixes and Puppeteer support for client side generated content

### DIFF
--- a/lib/authentication.js
+++ b/lib/authentication.js
@@ -1,0 +1,110 @@
+class AuthenticationManager {
+    constructor() {
+        this._authentications = {};
+    }
+
+    /**
+     *
+     * @param {String} domainName
+     * @return {boolean}
+     */
+    hasAuthFor(domainName) {
+        return Object.keys(this._authentications).length && domainName in this._authentications;
+    }
+
+    /**
+     *
+     * @param {String} domainName
+     * @return {AuthenticationBasic|AuthenticationX509}
+     */
+    getAuthFor(domainName) {
+        return this._authentications[domainName];
+    }
+
+    /**
+     * Set basic auth configuration for the specified domain name
+     * @param domainName
+     * @param username
+     * @param password
+     */
+    setBasicAuth(domainName, username, password) {
+        this._authentications[domainName] = new AuthenticationBasic(domainName, username, password);
+    }
+
+    /**
+     * Set cert auth configuration for the specified domain name
+     * @param domainName
+     * @param certificatePath
+     * @param certificatePassphrase
+     */
+    setX509Auth(domainName, certificatePath, certificatePassphrase) {
+        this._authentications[domainName] = new AuthenticationX509(domainName, certificatePath, certificatePassphrase);
+    }
+}
+
+class Authentication {
+    constructor(type, domainName) {
+        this._type = type;
+        this._domainName = domainName;
+    }
+
+    /**
+     *
+     * @return {String}
+     */
+    type() {
+        return this._type;
+    }
+
+    /**
+     * Which domain name the authentication data belongs to
+     * @return {String}
+     */
+    domainName() {
+        return this._domainName;
+    }
+}
+
+class AuthenticationBasic extends Authentication {
+    constructor(domainName, username, password) {
+        super(Authentication.Types.Basic, domainName);
+        this._username = username;
+        this._password = password;
+    }
+
+    username() {
+        return this._username;
+    }
+
+    password() {
+        return this._password;
+    }
+}
+
+class AuthenticationX509 extends Authentication {
+    constructor(domainName, certFilePath, certPassphrase) {
+        super(Authentication.Types.X509, domainName);
+        this._certFilePath = certFilePath;
+        this._certPassphrase = certPassphrase;
+    }
+
+    certFilePath() {
+        return this._certFilePath;
+    }
+
+    certPassPhrase() {
+        return this._certPassphrase;
+    }
+}
+
+Authentication.Types = {
+    Basic: "basic",
+    X509: "x509"
+};
+
+module.exports = {
+    AuthenticationManager,
+    Authentication,
+    AuthenticationBasic,
+    AuthenticationX509
+};

--- a/lib/crawler.js
+++ b/lib/crawler.js
@@ -14,6 +14,7 @@ var FetchQueue  = require("./queue.js"),
 var http            = require("http"),
     https           = require("https"),
     EventEmitter    = require("events").EventEmitter,
+    fs              = require("fs"),
     uri             = require("urijs"),
     async           = require("async"),
     zlib            = require("zlib"),
@@ -217,24 +218,10 @@ var Crawler = function(initialURL) {
     this.proxyPass = null;
 
     /**
-     * Controls whether to use HTTP Basic Auth
-     * @type {Boolean}
+     *
+     * @type {AuthenticationManager}
      */
-    this.needsAuth = false;
-
-    /**
-     * If {@link Crawler#needsAuth} is true, this setting controls what username
-     * to send with HTTP Basic Auth
-     * @type {String}
-     */
-    this.authUser = null;
-
-    /**
-     * If {@link Crawler#needsAuth} is true, this setting controls what password
-     * to send with HTTP Basic Auth
-     * @type {String}
-     */
-    this.authPass = null;
+    this.authentications = new AuthenticationManager();
 
     /**
      * Controls whether to save and send cookies or not
@@ -562,13 +549,17 @@ Crawler.prototype.getRequestOptions = function(queueItem) {
             crawler.cookies.getAsHeader(queueItem.host, queueItem.path);
     }
 
-    // Add auth headers if we need them
-    if (crawler.needsAuth) {
-        var auth = crawler.authUser + ":" + crawler.authPass;
-
-        // Generate auth header
-        auth = "Basic " + new Buffer(auth).toString("base64");
-        requestOptions.headers.Authorization = auth;
+    // apply basic or x509 auth for queueItems
+    if (crawler.authentications.hasAuthFor(queueItem.host)) {
+        const authConfig = crawler.authentications.getAuthFor(queueItem.host);
+        switch (authConfig.type()) {
+        case Authentication.Types.Basic:
+            applyBasicAuth(authConfig, requestOptions);
+            break;
+        case Authentication.Types.X509:
+            applyX509Auth(authConfig, requestOptions);
+            break;
+        }
     }
 
     // Add proxy auth if we need it
@@ -591,6 +582,27 @@ Crawler.prototype.getRequestOptions = function(queueItem) {
     }
 
     return requestOptions;
+
+    /**
+     * Applies basic auth to requestOptions
+     * @param {AuthenticationBasic} authConfig
+     * @param requestOptions
+     */
+    function applyBasicAuth(authConfig, requestOptions) {
+        const auth = "Basic " + new Buffer(authConfig.username() + ":" + authConfig.password()).toString("base64");
+        requestOptions.headers.Authorization = auth;
+    }
+
+    /**
+     * Applies X509 auth to requestOptions
+     * @param {AuthenticationX509} authConfig
+     * @param requestOptions
+     */
+    function applyX509Auth(authConfig, requestOptions) {
+        const certPath = authConfig.certFilePath;
+        requestOptions.pfx = fs.readFileSync(certPath);
+        requestOptions.passphrase = authConfig.passPhrase;
+    }
 };
 
 /**

--- a/lib/crawler.js
+++ b/lib/crawler.js
@@ -523,6 +523,10 @@ Crawler.prototype.getRequestOptions = function(queueItem) {
         isStandardHTTPSPort = queueItem.protocol === "https" && queueItem.port !== 443,
         isStandardPort = isStandardHTTPPort || isStandardHTTPSPort;
 
+    // prevent webservers from closing the tcp connection before the response was fully sent to the client
+    // fixes: Error: read ECONNRESET
+    agent.keepAlive = true;
+
     // Load in request options
     var requestOptions = {
         method: "GET",
@@ -531,6 +535,7 @@ Crawler.prototype.getRequestOptions = function(queueItem) {
         path: requestPath,
         agent: agent,
         headers: {
+            "Connection": "keep-alive",
             "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
             "User-Agent": crawler.userAgent,
             "Host": queueItem.host + (queueItem.port && isStandardPort ? ":" + queueItem.port : "")

--- a/lib/crawler.js
+++ b/lib/crawler.js
@@ -6,6 +6,9 @@
 
 var FetchQueue  = require("./queue.js"),
     CookieJar   = require("./cookies.js"),
+    { AuthenticationManager, Authentication } = require("./authentication"),
+    FetchClientPuppeteer = require("./fetch-client-puppeteer"),
+    ProxyAgent = require('proxy-agent'),
     packageJson = require("../package.json");
 
 var http            = require("http"),
@@ -512,9 +515,8 @@ Crawler.prototype.getRequestOptions = function(queueItem) {
 
     // Are we passing through an HTTP proxy?
     if (crawler.useProxy) {
-        requestHost = crawler.proxyHostname;
-        requestPort = crawler.proxyPort;
-        requestPath = queueItem.url;
+        const proxyUrl = `http://${crawler.proxyHostname}:${crawler.proxyPort}`;
+        agent = new ProxyAgent(proxyUrl);
     }
 
     var isStandardHTTPPort = queueItem.protocol === "http" && queueItem.port !== 80,
@@ -566,10 +568,11 @@ Crawler.prototype.getRequestOptions = function(queueItem) {
 
     // Add proxy auth if we need it
     if (crawler.proxyUser !== null && crawler.proxyPass !== null) {
-        var proxyAuth = crawler.proxyUser + ":" + crawler.proxyPass;
+        let proxyAuth = `${crawler.proxyUser}:${crawler.proxyPass}`;
 
         // Generate auth header
-        proxyAuth = "Basic " + new Buffer(proxyAuth).toString("base64");
+        proxyAuth = Buffer.from(proxyAuth).toString("base64");
+        proxyAuth = `Basic ${proxyAuth}`;
         requestOptions.headers["Proxy-Authorization"] = proxyAuth;
     }
 

--- a/lib/crawler.js
+++ b/lib/crawler.js
@@ -392,6 +392,20 @@ var Crawler = function(initialURL) {
      */
     this.httpsAgent = https.globalAgent;
 
+    /**
+     * Use puppeteer to render the pages
+     * Puppeteer uses a chrome/chromium instance to render the page
+     * This includes client side generated content via e.g. ajax
+     * @type {boolean}
+     */
+    this.clientSideGeneratedContent = false;
+
+    /**
+     * Provides abstractions to fetch a page using https://github.com/GoogleChrome/puppeteer
+     * @type {FetchClientPuppeteer}
+     */
+    this.fetchClientPuppeteer = null;
+
     // STATE (AND OTHER) VARIABLES NOT TO STUFF WITH
     var hiddenProps = {
         _downloadConditions: [],
@@ -428,6 +442,8 @@ Crawler.prototype.start = function() {
     if (crawler.running) {
         return crawler;
     }
+
+    crawler.fetchClientPuppeteer = new FetchClientPuppeteer(crawler);
 
     crawler.running = true;
 
@@ -1178,6 +1194,25 @@ Crawler.prototype.queueURL = function(url, referrer, force) {
  * @return {Crawler}             Returns the crawler instance to enable chained API calls
  */
 Crawler.prototype.fetchQueueItem = function(queueItem) {
+    var crawler = this;
+    if (crawler.clientSideGeneratedContent) {
+        crawler.fetchClientPuppeteer.fetch(queueItem);
+        return crawler;
+    }
+    return crawler.fetchQueueItemDefault(queueItem);
+};
+
+/**
+ * Handles the initial fetching of a queue item. Once an initial response has
+ * been received, {@link Crawler#handleResponse} will handle the downloading of
+ * the resource data
+ * @fires  Crawler#fetchstart
+ * @fires  Crawler#fetchtimeout
+ * @fires  Crawler#fetchclienterror
+ * @param  {QueueItem} queueItem The queue item that will be fetched
+ * @return {Crawler}             Returns the crawler instance to enable chained API calls
+ */
+Crawler.prototype.fetchQueueItemDefault = function(queueItem) {
     var crawler = this;
 
     crawler.queue.update(queueItem.id, {

--- a/lib/fetch-client-puppeteer.js
+++ b/lib/fetch-client-puppeteer.js
@@ -1,0 +1,263 @@
+const puppeteer = require("puppeteer");
+const { AuthenticationBasic } = require("./authentication");
+
+class FetchClientPuppeteer {
+    /**
+     *
+     * @param {Crawler} crawler
+     */
+    constructor(crawler) {
+        this._crawler = crawler;
+        this._browser = null;
+    }
+
+    /**
+     * Starts a new browser for puppeteer or reuses the the running instance
+     * @returns {Promise<Browser>}
+     */
+    browser() {
+        if (!this._browser) {
+            const options = {
+                headless: true,
+                ignoreHTTPSErrors: this._crawler.ignoreInvalidSSL
+            };
+            let proxyUrl = this._proxyUrl();
+            if (proxyUrl) {
+                let args = [`--proxy-server=${proxyUrl}`];
+                options.args = args;
+            }
+            this._browser = puppeteer.launch(options).catch((error) => {
+                throw error;
+            });
+        }
+        return this._browser;
+    }
+
+    /**
+     * Fetches the url specified in the queueItem
+     * @param queueItem
+     * @return {Void}
+     */
+    fetch(queueItem) {
+        this._crawler.queue.update(queueItem.id, {
+            status: "spooled"
+        }, (error, queueItem) => {
+            if (error) {
+                return this._crawler.emit("queueerror", error, queueItem);
+            }
+
+            this.browser().then((browser) => {
+                browser.newPage().then((page) => {
+                    const timeCommenced = Date.now();
+                    const options = {
+                        timeout: this._crawler.timeout,
+                        waitUntil: "networkidle",
+                        networkIdleInflight: 0
+                    };
+                    page.authenticate(this._basicAuthCredentials(queueItem.host)).then(() => {
+                        page.goto(queueItem.url, options)
+                            .then((response) => {
+                                // _openRequests.length is used for rate limiting in crawler
+                                this._crawler._openRequests.push(response._request);
+                                this._fixResponse(response);
+                                this.handleResponse(queueItem, response, timeCommenced, page);
+                            })
+                            .catch((error) => {
+                                if (error.message.match(/timeout/i)) {
+                                    this._onTimeout(error, queueItem);
+                                } else {
+                                    this._onError(error, queueItem);
+                                }
+                                this._cleanup(page);
+                            });
+                    });
+                });
+            });
+        });
+    }
+
+    /**
+     * Handles the response of the item fetched via fetch()
+     * @param queueItem
+     * @param response
+     * @param timeCommenced
+     * @param page
+     */
+    handleResponse(queueItem, response, timeCommenced, page) {
+        const timeHeadersReceived = Date.now();
+        let responseLength;
+
+        timeCommenced = timeCommenced || Date.now();
+        responseLength = Number(response.headers["content-length"]);
+        responseLength = !isNaN(responseLength) ? responseLength : 0;
+
+        this._crawler.queue.update(queueItem.id, {
+            stateData: {
+                requestLatency: timeHeadersReceived - timeCommenced,
+                requestTime: timeHeadersReceived - timeCommenced,
+                contentLength: responseLength,
+                contentType: response.headers["content-type"],
+                code: response.status,
+                headers: response.headers
+            }
+        }, (error, queueItem) => {
+            if (error) {
+                return this._crawler.emit("queueerror", error, queueItem);
+            }
+            this._crawler.emit("fetchheaders", queueItem, response);
+        });
+        this._crawler.queue.update(queueItem.id, {
+            fetched: true,
+            status: "downloaded"
+        }, (error, queueItem) => {
+            if (error) {
+                return this._crawler.emit("queueerror", error, queueItem);
+            }
+
+            /**
+             * Fired when the request has completed
+             * @event Crawler#fetchcomplete
+             * @param {QueueItem} queueItem           The queue item for which the request has completed
+             * @param {String} responseBody
+             * @param {Response} response
+             */
+            page.content().then((responseBody) => {
+                this._crawler.emit("fetchcomplete", queueItem, responseBody, response);
+                this._cleanup(page, response);
+            });
+        });
+    }
+
+    /**
+     * Returns a proxy URL with the format:
+     * http://username:password@hostname:port
+     * @return {String}
+     * @private
+     */
+    _proxyUrl() {
+        let proxyUrl = [];
+        if (this._crawler.useProxy) {
+            proxyUrl.push("http://");
+            if (this._crawler.proxyUser !== null && this._crawler.proxyPass !== null) {
+                proxyUrl.push(`${this._crawler.proxyUser}:${this._crawler.proxyPass}@`);
+            }
+            proxyUrl.push(`${this._crawler.proxyHostname}:${this._crawler.proxyPort}`);
+        }
+        return proxyUrl.length ? proxyUrl.join("") : null;
+    }
+
+    /**
+     * Handle resources cleanup once we're done fetching the resource
+     * @param  {Page} page
+     * @param {Response} response
+     * @return {Promise} when the page is closed
+     * @private
+     */
+    _cleanup(page, response = null) {
+        if (response) {
+            this._crawler._openRequests.splice(this._crawler._openRequests.indexOf(response._request), 1);
+        }
+        return page.close();
+    }
+
+    /**
+     * Returns the basic auth credentials for the host if there are any.
+     * @param{String} host
+     * @param {Page} page
+     * @returns {Object|null} credentials or null if the host needs none
+     * @private
+     */
+    _basicAuthCredentials(host) {
+        if (this._crawler.authentications.hasAuthFor(host)) {
+            const authConfig = this._crawler.authentications.getAuthFor(host);
+            if (authConfig instanceof AuthenticationBasic) {
+                return {
+                    username: authConfig.username(),
+                    password: authConfig.password()
+                };
+            }
+        }
+        return null;
+    }
+
+    /**
+     * The configured crawler timeout has expired.
+     * @param error
+     * @param {QueueItem} queueItem
+     * @private
+     */
+    _onTimeout(error, queueItem) {
+        this._crawler.queue.update(queueItem.id, {
+            fetched: true,
+            status: "timeout"
+        }, (error, queueItem) => {
+            if (error) {
+                return this._crawler.emit("queueerror", error, queueItem);
+            }
+
+            /**
+             * Fired when a request times out
+             * @event Crawler#fetchtimeout
+             * @param {QueueItem} queueItem The queue item for which the request timed out
+             * @param {Number} timeout      The delay in milliseconds after which the request timed out
+             */
+            this._crawler.emit("fetchtimeout", queueItem, this._crawler.timeout);
+        });
+    }
+
+    /**
+     * Unknown error prevented the fetch operation.
+     * @param pageError
+     * @param {QueueItem} queueItem
+     * @private
+     */
+    _onError(pageError, queueItem) {
+        this._crawler.queue.update(queueItem.id, {
+            fetched: true,
+            status: "failed",
+            stateData: {
+                code: 600
+            }
+        }, (queueError, queueItem) => {
+            if (queueError) {
+                return this._crawler.emit("queueerror", queueError, queueItem);
+            }
+        });
+        /**
+         * Fired when a request encounters an unknown error
+         * @event Crawler#fetchclienterror
+         * @param {QueueItem} queueItem The queue item for which the request has errored
+         * @param {Object} error        The error supplied to the `error` event on the request
+         */
+        this._crawler.emit("fetchclienterror", queueItem, pageError);
+    }
+
+    /**
+     * Adds properties to the request object from puppeteer to more closely match those of the request
+     * as returned by Node.js' http client request instance
+     * This is a hack to make the existing crawler code "work"
+     * @param response
+     * @private
+     */
+    _fixResponse(response) {
+        // hacks to make interfaces compatible with the existing crawler to some extent
+        // add aliases for properties to make puppeteers interface for responses match that of node.js
+        Object.defineProperty(response, "statusCode", {
+            get: function () {
+                return this.status;
+            }
+        });
+        Object.defineProperty(response, "req", {
+            get: function () {
+                return this._request;
+            }
+        });
+        Object.defineProperty(response._request, "_headers", {
+            get: function () {
+                return this.headers;
+            }
+        });
+    }
+}
+
+module.exports = FetchClientPuppeteer;

--- a/package.json
+++ b/package.json
@@ -38,6 +38,8 @@
   "dependencies": {
     "async": "^2.1.4",
     "iconv-lite": "^0.4.13",
+    "proxy-agent": "^2.1.0",
+    "puppeteer": "^0.11.0",
     "robots-parser": "^1.0.0",
     "urijs": "^1.18.11"
   },


### PR DESCRIPTION
- *Did you make sure the commit messages are clear, and WIP commits have been squashed?*
- *Did you lint and test the code (`npm test`)?*  Passes for Node.js >= v6.4.0
- *Did you include tests for your code?* No
- *If applicable, did you update the documentation with the changes you made?* No
- *If you made changes to the docs, did you run a quick spell check?* No

## What this PR changes
* optionally use puppeteer for fetch queueItems. This enables crawling of client side generated content (e.g. ajax) and is one solution to #386 . The feature can be enabled by setting `crawler.clientSideGeneratedContent =  true;`
* always sets `Connection: keep-alive`, because we've encountered slow (application) webservers closing connections before the response was fully sent/received. Chrome seems to do the same.
* Implements http basic and x.509 certificate authentication for individual hosts instead
* refactors the proxy crawler implementation, because according it needs to be handled differently depending on the protocol of the queueItem or the proxy. For now I've used https://www.npmjs.com/package/tunnel which supports all combinations and http basic auth. I've only implemented http over httpand https over http in the crawler for now.

## Rationale
* the integration of puppeteer is one way of solving #386 
* the new proxy implementation might also solve #336 . Needs verification.

* as mentioned in #361 we should probably  add some docs about supported proxy configurations

As you can see in https://github.com/konstantinblaesi/node-simplecrawler/blob/c44f0b4ec18e3d7fc653eb114fa150996b9a2dd2/lib/fetch-client-puppeteer.js#L242 there are some ugly hacks to make the current crawler work with the request/response objects returned by puppeteer, because the current crawler has no generic abstractions for these and simply exposes them in different ways.

Puppeteer requires Node.js  >= v6.4.0 or better >= v7.6.0 .
I'd like to do more refactoring/cleanup making use of async/await including adding missing abstractions. Async/await requires Node.js 8.x (becoming LTS in october) unless you do transpiling one way or another.
What do you think about merging some or all of these commits?
What do you think about raising the Node.js version to >= v7.6 (async/await support) ?