### PR TITLE
Add a replacement in cleanURL

### DIFF
--- a/lib/crawler.js
+++ b/lib/crawler.js
@@ -828,6 +828,7 @@ function cleanURL (URL, queueItem) {
         .replace(/&amp;/gi, "&")
         .replace(/&#38;/gi, "&")
         .replace(/&#x00026;/gi, "&")
+        .replace(/&#x2f;/gi, "/")
         .split("#")
         .shift()
         .trim();


### PR DESCRIPTION
This pull request is fixing an unimplemented special char case in URLs.