### PR TITLE
savetodisk: fix require error

### DIFF
--- a/example/savetodisk.js
+++ b/example/savetodisk.js
@@ -8,7 +8,7 @@ var downloadSite = function(initialURL, callback) {
     var fs = require("node-fs"),
         url = require("url"),
         path = require("path"),
-        Crawler = require("simplecrawler").Crawler;
+        Crawler = require("simplecrawler");
 
     var myCrawler = new Crawler(initialURL),
         domain = url.parse(initialURL).hostname;


### PR DESCRIPTION
I received an error with: "TypeError: Crawler is not a constructor".
This is the fix for the require.