### PR TITLE
Make tests to run independently

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,7 +4,7 @@
 root = true
 
 [*]
-charset = "utf8"
+charset = utf-8
 end_of_line = lf
 indent_size = 4
 indent_style = space

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 docs
 /test/queue.json
 /npm-debug.log
+.idea

--- a/test/conditions.js
+++ b/test/conditions.js
@@ -4,6 +4,9 @@ var chai = require("chai"),
     http = require("http"),
     Crawler = require("../");
 
+var routes = require("./lib/routes.js"),
+    Server = require("./lib/testserver.js");
+
 var should = chai.should();
 
 var makeCrawler = function (url) {
@@ -14,6 +17,15 @@ var makeCrawler = function (url) {
 
 describe("Fetch conditions", function() {
     this.slow("150ms");
+
+    before(function (done) {
+        this.server = new Server(routes);
+        this.server.listen(3000, done);
+    });
+
+    after(function (done) {
+        this.server.close(done);
+    });
 
     it("should be able to add a fetch condition", function() {
         var crawler = makeCrawler("http://127.0.0.1:3000"),
@@ -268,6 +280,15 @@ describe("Fetch conditions", function() {
 });
 
 describe("Download conditions", function() {
+    before(function (done) {
+        this.server = new Server(routes);
+        this.server.listen(3000, done);
+    });
+
+    after(function (done) {
+        this.server.close(done);
+    });
+
     it("should be able to add a download condition", function() {
         var crawler = makeCrawler("http://127.0.0.1:3000"),
             condition = function() {},

--- a/test/depth.js
+++ b/test/depth.js
@@ -6,9 +6,6 @@ var chai = require("chai"),
 var routes = require("./lib/routes.js"),
     Server = require("./lib/testserver.js");
 
-var server = new Server(routes);
-server.listen(3000);
-
 chai.should();
 
 function depthTest(maxDepth, linksToDiscover) {
@@ -36,6 +33,15 @@ function depthTest(maxDepth, linksToDiscover) {
 
 describe("Crawler max depth", function() {
     this.slow("300ms");
+
+    before(function (done) {
+        this.server = new Server(routes);
+        this.server.listen(3000, done);
+    });
+
+    after(function (done) {
+        this.server.close(done);
+    });
 
     var maxDepthToResourceCount = {
         0: 11, // maxDepth=0 (no max depth) should return 11 resources

--- a/test/queue.js
+++ b/test/queue.js
@@ -4,6 +4,9 @@ var chai = require("chai"),
     Crawler = require("../"),
     queue = require("./fixtures/queue.json");
 
+var routes = require("./lib/routes.js"),
+    Server = require("./lib/testserver.js");
+
 var should = chai.should();
 
 function find(array, callback) {
@@ -64,6 +67,15 @@ describe("Queue methods", function() {
             updateItem(0);
         });
     };
+
+    before(function (done) {
+        this.server = new Server(routes);
+        this.server.listen(3000, done);
+    });
+
+    after(function (done) {
+        this.server.close(done);
+    });
 
     it("should add to the queue", addToQueue);
 

--- a/test/reliability.js
+++ b/test/reliability.js
@@ -6,6 +6,9 @@ var path = require("path"),
 
 var Crawler = require("../");
 
+var routes = require("./lib/routes.js"),
+    Server = require("./lib/testserver.js");
+
 var should = chai.should();
 
 var makeCrawler = function (url) {
@@ -17,6 +20,15 @@ var makeCrawler = function (url) {
 // Runs a very simple crawl on an HTTP server
 describe("Crawler reliability", function() {
     this.slow("600ms");
+
+    before(function (done) {
+        this.server = new Server(routes);
+        this.server.listen(3000, done);
+    });
+
+    after(function (done) {
+        this.server.destroy(done);
+    });
 
     it("should be able to be started, then stopped, then started again", function(done) {
         var crawler = makeCrawler("http://127.0.0.1:3000/"),

--- a/test/resourcevalidity.js
+++ b/test/resourcevalidity.js
@@ -10,6 +10,9 @@ chai.should();
 
 var Crawler = require("../");
 
+var routes = require("./lib/routes.js"),
+    Server = require("./lib/testserver.js");
+
 var makeCrawler = function (url) {
     var crawler = new Crawler(url);
     crawler.interval = 5;
@@ -17,6 +20,15 @@ var makeCrawler = function (url) {
 };
 
 describe("Resource validity checker", function() {
+
+    before(function (done) {
+        this.server = new Server(routes);
+        this.server.listen(3000, done);
+    });
+
+    after(function (done) {
+        this.server.close(done);
+    });
 
     it("should be able to determine whether a domain is in crawl scope", function() {
 

--- a/test/testcrawl.js
+++ b/test/testcrawl.js
@@ -6,8 +6,10 @@
 var chai = require("chai"),
     uri = require("urijs");
 
-var Server = require("./lib/testserver.js"),
-    Crawler = require("../");
+var Crawler = require("../");
+
+var routes = require("./lib/routes.js"),
+    Server = require("./lib/testserver.js");
 
 chai.should();
 
@@ -19,6 +21,15 @@ var makeCrawler = function (url) {
 
 describe("Test Crawl", function() {
     this.slow("200ms");
+
+    before(function (done) {
+        this.server = new Server(routes);
+        this.server.listen(3000, done);
+    });
+
+    after(function (done) {
+        this.server.close(done);
+    });
 
     it("should be able to be started", function(done) {
         var crawler = makeCrawler("http://127.0.0.1:3000/");


### PR DESCRIPTION
## What this PR changes
Currently the tests can't be run independently because they rely on the local server which started in one of the files. That is uncomfortable when working with a particular file. This commit adds the server to every file where necessary.

Also, fixed typo in `.editorconfig` and added WebStorm IDE's project folder to `.gitignore`.