### PR TITLE
fix: get rid of multiple `fetchQueueItem` execution for the same items

### DIFF
--- a/lib/crawler.js
+++ b/lib/crawler.js
@@ -1160,9 +1160,13 @@ Crawler.prototype.queueURL = function(url, referrer, force) {
 Crawler.prototype.fetchQueueItem = function(queueItem) {
     var crawler = this;
 
+    crawler.fetchingQueueItem = true;
+
     crawler.queue.update(queueItem.id, {
         status: "spooled"
     }, function(error, queueItem) {
+        crawler.fetchingQueueItem = false;
+
         if (error) {
             return crawler.emit("queueerror", error, queueItem);
         }
@@ -1731,11 +1735,18 @@ Crawler.prototype.crawl = function() {
     var crawler = this;
 
     if (crawler._openRequests.length >= crawler.maxConcurrency ||
-        crawler.fetchingRobotsTxt) {
+        crawler.fetchingRobotsTxt || crawler.fetchingQueueItem) {
         return crawler;
     }
 
+    // The flag means the fetching process begins which includes finding of oldest unfetched item and
+    // updating its status to `spooled`. It is required to avoid multiple fetching of the same item
+    // at defined interval in case of slow queue implementation (DB, for example)
+    crawler.fetchingQueueItem = true;
+
     crawler.queue.oldestUnfetchedItem(function(error, queueItem) {
+        crawler.fetchingQueueItem = false;
+
         if (error) {
             // Do nothing
         } else if (queueItem) {


### PR DESCRIPTION
This PR fixes #443