### PR TITLE
Fix: handle unwanted path char in chaching file path

### DIFF
--- a/lib/cache-backend-fs.js
+++ b/lib/cache-backend-fs.js
@@ -45,8 +45,8 @@ function sanitisePath(path, queueObject) {
     if (sanitisedPath.match(/\?/)) {
         sanitisedPathParts = sanitisedPath.split(/\?/g);
         var resource = sanitisedPathParts.shift();
-        var hashedQS = crypto.createHash("sha1").update(sanitisedPathParts.join("?")).digest("hex");
-        sanitisedPath = resource + "?" + hashedQS;
+        var hashedQS = crypto.createHash("sha1").update(sanitisedPathParts.join("_")).digest("hex");
+        sanitisedPath = resource + "_" + hashedQS;
     }
 
     pathStack = sanitisedPath.split(/\//g);


### PR DESCRIPTION
## What this PR changes
On Windows crawling with default cache enabled crashed, if the crawled URL contained a '?'.
This behavior is fixed with this change.

## Rationale
https://github.com/simplecrawler/simplecrawler/issues/314