### PR TITLE
Rewrite deprecated use of `Buffer`

### DIFF
--- a/lib/crawler.js
+++ b/lib/crawler.js
@@ -560,7 +560,7 @@ Crawler.prototype.getRequestOptions = function(queueItem) {
         var auth = crawler.authUser + ":" + crawler.authPass;
 
         // Generate auth header
-        auth = "Basic " + new Buffer(auth).toString("base64");
+        auth = "Basic " + Buffer.from(auth).toString("base64");
         requestOptions.headers.Authorization = auth;
     }
 
@@ -569,7 +569,7 @@ Crawler.prototype.getRequestOptions = function(queueItem) {
         var proxyAuth = crawler.proxyUser + ":" + crawler.proxyPass;
 
         // Generate auth header
-        proxyAuth = "Basic " + new Buffer(proxyAuth).toString("base64");
+        proxyAuth = "Basic " + Buffer.from(proxyAuth).toString("base64");
         requestOptions.headers["Proxy-Authorization"] = proxyAuth;
     }
 
@@ -612,7 +612,7 @@ Crawler.prototype.getRobotsTxt = function(url, callback) {
             var responseLength =
                     parseInt(response.headers["content-length"], 10) ||
                     crawler.maxResourceSize,
-                responseBuffer = new Buffer(responseLength),
+                responseBuffer = Buffer.alloc(responseLength),
                 responseLengthReceived = 0;
 
             response.on("data", function(chunk) {
@@ -1444,7 +1444,7 @@ Crawler.prototype.handleResponse = function(queueItem, response, timeCommenced) 
                         }
 
                         // Create a buffer with our response length
-                        responseBuffer = new Buffer(responseLength);
+                        responseBuffer = Buffer.alloc(responseLength);
 
                         // Only if we're prepared to download non-text resources...
                         if (crawler.downloadUnsupported || crawler.mimeTypeSupported(contentType)) {
@@ -1691,7 +1691,7 @@ Crawler.prototype.handleResponse = function(queueItem, response, timeCommenced) 
 
                     // Create a temporary buffer with the new response length, copy
                     // the old data into it and replace the old buffer with it
-                    var tmpNewBuffer = new Buffer(responseLengthReceived + chunk.length);
+                    var tmpNewBuffer = Buffer.alloc(responseLengthReceived + chunk.length);
                     responseBuffer.copy(tmpNewBuffer, 0, 0, responseBuffer.length);
                     chunk.copy(tmpNewBuffer, responseBuffer.length, 0, chunk.length);
                     responseBuffer = tmpNewBuffer;

--- a/test/lib/routes.js
+++ b/test/lib/routes.js
@@ -189,6 +189,6 @@ module.exports = {
     },
 
     "/big": function(write) {
-        write(200, new Buffer(1024 * 1024 * 17));
+        write(200, Buffer.alloc(1024 * 1024 * 17));
     }
 };


### PR DESCRIPTION
## What this PR changes
The constructor `new Buffer` was [deprecated](https://nodejs.org/docs/latest-v10.x/api/buffer.html) since Node.js 6.0.0. The new APIs `Buffer.from` and `Buffer.alloc` [should be used](https://nodejs.org/docs/latest-v10.x/api/buffer.html#buffer_buffer_from_buffer_alloc_and_buffer_allocunsafe) instead.