### PR TITLE
Fix docs of events `crawlstart` and `discoverycomplete`

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,23 +111,23 @@ crawler.start();
 
 simplecrawler's API is event driven, and there are plenty of events emitted during the different stages of the crawl.
 
-<a name="Crawler+event_fetchstart"></a>
+<a name="Crawler+event_crawlstart"></a>
 
-#### "fetchstart"
+#### "crawlstart"
 Fired when the crawl starts. This event gives you the opportunity to
 adjust the crawler's configuration, since the crawl won't actually start
 until the next processor tick.
 
-<a name="Crawler+event_fetchtimeout"></a>
+<a name="Crawler+event_discoverycomplete"></a>
 
-#### "fetchtimeout" (queueItem, timeout)
-Fired when a request times out
+#### "discoverycomplete" (queueItem, resources)
+Fired when the discovery of linked resources has completed
 
 
 | Param | Type | Description |
 | --- | --- | --- |
-| queueItem | [<code>QueueItem</code>](#QueueItem) | The queue item for which the request timed out |
-| timeout | <code>Number</code> | The delay in milliseconds after which the request timed out |
+| queueItem | [<code>QueueItem</code>](#QueueItem) | The queue item that represents the document for the discovered resources |
+| resources | <code>Array</code> | An array of discovered and cleaned URL's |
 
 <a name="Crawler+event_invaliddomain"></a>
 

--- a/lib/crawler.js
+++ b/lib/crawler.js
@@ -461,7 +461,7 @@ Crawler.prototype.start = function() {
          * Fired when the crawl starts. This event gives you the opportunity to
          * adjust the crawler's configuration, since the crawl won't actually start
          * until the next processor tick.
-         * @event Crawler#fetchstart
+         * @event Crawler#crawlstart
          */
         crawler.emit("crawlstart");
     });
@@ -1015,10 +1015,10 @@ Crawler.prototype.queueLinkedItems = function(resourceData, queueItem) {
     resources = crawler.cleanExpandResources(resources, queueItem);
 
     /**
-     * Fired when a request times out
-     * @event Crawler#fetchtimeout
-     * @param {QueueItem} queueItem The queue item for which the request timed out
-     * @param {Number} timeout      The delay in milliseconds after which the request timed out
+     * Fired when the discovery of linked resources has completed
+     * @event Crawler#discoverycomplete
+     * @param {QueueItem} queueItem The queue item that represents the document for the discovered resources
+     * @param {Array} resources     An array of discovered and cleaned URL's
      */
     crawler.emit("discoverycomplete", queueItem, resources);
 


### PR DESCRIPTION
## What this PR changes
Fixes the docs of events `crawlstart` and `discoverycomplete`

~~NOTE: This PR is based on top of #457.  I separated the changes so you can merge that PR first and then review the actual changes in this PR separately.~~

## Rationale
Doc fixes
