### PR TITLE
fix jsdoc2md generated links

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@
 [![Linux Build Status](https://img.shields.io/travis/simplecrawler/simplecrawler/master.svg)](https://travis-ci.org/simplecrawler/simplecrawler)
 [![Windows Build Status](https://img.shields.io/appveyor/ci/fredrikekelund/simplecrawler.svg?label=Windows%20build)](https://ci.appveyor.com/project/fredrikekelund/simplecrawler/branch/master)
 [![Dependency Status](https://img.shields.io/david/simplecrawler/simplecrawler.svg)](https://david-dm.org/simplecrawler/simplecrawler)
-[![devDependency Status](https://img.shields.io/david/dev/simplecrawler/simplecrawler.svg)](https://david-dm.org/simplecrawler/simplecrawler?type=dev) [![Greenkeeper badge](https://badges.greenkeeper.io/simplecrawler/simplecrawler.svg)](https://greenkeeper.io/)
+[![devDependency Status](https://img.shields.io/david/dev/simplecrawler/simplecrawler.svg)](https://david-dm.org/simplecrawler/simplecrawler?type=dev)
+[![Greenkeeper badge](https://badges.greenkeeper.io/simplecrawler/simplecrawler.svg)](https://greenkeeper.io/)
 
 simplecrawler is designed to provide a basic, flexible and robust API for crawling websites. It was written to archive, analyse, and search some very large websites and has happily chewed through hundreds of thousands of pages and written tens of gigabytes to disk without issue.
 

--- a/jsdoc2md/link.hbs
+++ b/jsdoc2md/link.hbs
@@ -1,0 +1,25 @@
+{{! usage: link to="namepath" html=true/false caption="optional caption"~}}
+
+{{~#if html~}}
+<code>
+
+{{~#link to~}}
+{{#if url~}}
+<a href="{{{url}}}">{{#if ../caption}}{{../caption}}{{else}}{{name}}{{/if}}</a>
+{{~else~}}
+{{#if ../caption}}{{../caption}}{{else}}{{name}}{{/if~}}
+{{/if~}}
+{{/link~}}
+
+</code>
+{{~else~}}
+
+{{#link to~}}
+{{#if url~}}
+[<code>{{#if ../caption}}{{escape ../caption}}{{else}}{{escape name}}{{/if}}</code>]({{{url}}})
+{{~else~}}
+<code>{{#if ../caption}}{{escape ../caption}}{{else}}{{escape name}}{{/if~}}</code>
+{{~/if~}}
+{{/link~}}
+
+{{/if~}}


### PR DESCRIPTION
I've noticed that `npm run docs` changes some links in the README as in [this PR](https://github.com/simplecrawler/simplecrawler/pull/457). Looks like the jsdoc2md ignores the `caption` attribute of the link for some reason. I'm not sure if it's an issue or not but was able to fix that with the own link partial.