### PR TITLE
cache: send headers If-None-Match and If-Modified-Since

### DIFF
--- a/lib/crawler.js
+++ b/lib/crawler.js
@@ -573,6 +573,19 @@ Crawler.prototype.getRequestOptions = function(queueItem) {
         requestOptions.headers["Proxy-Authorization"] = proxyAuth;
     }
 
+    if (crawler.cache !== null && crawler.cache.getCacheData) {
+        crawler.cache.getCacheData(queueItem, function(cacheObject) {
+            if (cacheObject) {
+                if (cacheObject.etag) {
+                    requestOptions.headers["If-None-Match"] = cacheObject.etag;
+                }
+                if (cacheObject.lastModified) {
+                    requestOptions.headers["If-Modified-Since"] = cacheObject.lastModified;
+                }
+            }
+        });
+    }
+
     // And if we've got any custom headers available
     if (crawler.customHeaders) {
         for (var header in crawler.customHeaders) {
@@ -1471,28 +1484,33 @@ Crawler.prototype.handleResponse = function(queueItem, response, timeCommenced) 
         // We've got a not-modified response back
         } else if (response.statusCode === 304) {
 
-            if (crawler.cache !== null && crawler.cache.getCacheData) {
-                // We've got access to a cache
-                crawler.cache.getCacheData(queueItem, function(cacheObject) {
-                    crawler.emit("notmodified", queueItem, response, cacheObject);
-                });
-            } else {
-                /**
-                 * Fired when the crawler's cache was enabled and the server responded with a 304 Not Modified status for the request
-                 * @event Crawler#notmodified
-                 * @param {QueueItem} queueItem           The queue item for which the request returned a 304 status
-                 * @param {http.IncomingMessage} response The [http.IncomingMessage]{@link https://nodejs.org/api/http.html#http_class_http_incomingmessage} for the request's response
-                 * @param {CacheObject} cacheObject       The CacheObject returned from the cache backend
-                 */
-                crawler.emit("notmodified", queueItem, response);
-            }
+            crawler.queue.update(queueItem.id, {
+                fetched: true
+            }, function(error, queueItem) {
 
-            response.destroy();
-            // Remove this request from the open request map
-            crawler._openRequests.splice(
-                crawler._openRequests.indexOf(response.req), 1);
+                if (crawler.cache !== null && crawler.cache.getCacheData) {
+                    // We've got access to a cache
+                    crawler.cache.getCacheData(queueItem, function(cacheObject) {
+                        crawler.emit("notmodified", queueItem, response, cacheObject);
+                    });
+                } else {
+                    /**
+                     * Fired when the crawler's cache was enabled and the server responded with a 304 Not Modified status for the request
+                     * @event Crawler#notmodified
+                     * @param {QueueItem} queueItem           The queue item for which the request returned a 304 status
+                     * @param {http.IncomingMessage} response The [http.IncomingMessage]{@link https://nodejs.org/api/http.html#http_class_http_incomingmessage} for the request's response
+                     * @param {CacheObject} cacheObject       The CacheObject returned from the cache backend
+                     */
+                    crawler.emit("notmodified", queueItem, response);
+                }
 
-            crawler._isFirstRequest = false;
+                response.destroy();
+                // Remove this request from the open request map
+                crawler._openRequests.splice(
+                    crawler._openRequests.indexOf(response.req), 1);
+
+                crawler._isFirstRequest = false;
+            });
 
         // If we should queue a redirect
         } else if (response.statusCode >= 300 && response.statusCode < 400 && response.headers.location) {

--- a/test/lib/routes.js
+++ b/test/lib/routes.js
@@ -146,6 +146,25 @@ module.exports = {
         write(410, "this page no longer exists!");
     },
 
+    "/etag": function(write, redir, req) {
+        var etag = "\"3c1ceb-13e84-5893853673580;589c03961f340\"";
+        if (req.headers["if-none-match"] === etag) {
+            write(304, "Not Modified", { ETag: etag });
+        } else {
+            write(200, "", { ETag: etag });
+        }
+    },
+
+    "/last-modified": function(write, redir, req) {
+        var lastmod = "Sun, 19 May 2019 07:11:34 GMT";
+        var ifmod = req.headers["if-modified-since"];
+        if (ifmod && new Date(lastmod) <= new Date(ifmod)) {
+            write(304, "Not Modified", { "Last-Modified": lastmod });
+        } else {
+            write(200, "", { "Last-Modified": lastmod });
+        }
+    },
+
     "/script": function(write) {
         write(200, "<script src='/not/existent/file.js'></script><script>var foo = 'bar';</script><a href='/stage2'>stage2</a><script>var bar = 'foo';</script>");
     },

--- a/test/lib/testserver.js
+++ b/test/lib/testserver.js
@@ -61,7 +61,7 @@ var Server = function(routes) {
 
             // Pass in a function that takes a status and some data to write back
             // out to the client
-            routes[req.url](write, redir);
+            routes[req.url](write, redir, req);
         } else {
 
             // Otherwise, a 404

--- a/test/notmodified.js
+++ b/test/notmodified.js
@@ -1,0 +1,61 @@
+/* eslint-env mocha */
+
+var path = require("path"),
+    fs = require("fs"),
+    chai = require("chai");
+
+var Crawler = require("../");
+var Cache = Crawler.cache;
+
+var routes = require("./lib/routes.js"),
+    Server = require("./lib/testserver.js");
+
+chai.should();
+
+var makeCrawler = function (url) {
+    var crawler = new Crawler(url);
+    var cachedir = path.join(__dirname, "cache");
+    if (!fs.existsSync(cachedir)) {
+        fs.mkdirSync(cachedir);
+    }
+    crawler.cache = new Cache(cachedir);
+    return crawler;
+};
+
+function notmodifiedTest(url, done) {
+    var crawler1 = makeCrawler(url);
+    crawler1.on("complete", function() {
+        crawler1.cache.saveCache();
+
+        var crawler2 = makeCrawler(url);
+        var notmodified = false;
+        crawler2.on("notmodified", function() {
+            notmodified = true;
+        });
+        crawler2.on("complete", function() {
+            notmodified.should.equal(true);
+            done();
+        });
+        crawler2.start();
+    });
+    crawler1.start();
+}
+
+describe("Cache and notmodified event", function() {
+    before(function (done) {
+        this.server = new Server(routes);
+        this.server.listen(3000, done);
+    });
+
+    after(function (done) {
+        this.server.destroy(done);
+    });
+
+    it("should emit a notmodified when given a 304 status code by ETag", function(done) {
+        notmodifiedTest("http://127.0.0.1:3000/etag", done);
+    });
+
+    it("should emit a notmodified when given a 304 status code by Last-Modified", function(done) {
+        notmodifiedTest("http://127.0.0.1:3000/last-modified", done);
+    });
+});


### PR DESCRIPTION
## What this PR changes
This PR adds If-None-Match or If-Modified-Since header to fetch request
when fetching url is in cache and ETag or Last-Modified value is cached.

This PR also updates queue
on received 304 not-modified response from server.
Otherwise, crawler does not emit "complete" event.

This PR resolves #375.

