### PR TITLE
Fix format in FS cache backend error constructor (take 2)

### DIFF
--- a/lib/cache-backend-fs.js
+++ b/lib/cache-backend-fs.js
@@ -196,7 +196,7 @@ FSBackend.prototype.setItem = function(queueObject, data, callback) {
                     // Just overwrite the file...
                     writeFileData(currentPath, data);
                 } else {
-                    throw new Error("Cache storage of resource (%s) blocked by file: %s", queueObject.url, currentPath);
+                    throw new Error(`Cache storage of resource (${queueObject.url}) blocked by file: ${currentPath}`);
                 }
             }
         } else if (count === pathStack.length - 1) {


### PR DESCRIPTION
**This PR was originally filed as #483. I’m recreating it to try and resolve issues with Travis.**

## What this PR changes

This switches the error constructor in the cache's FS backend to use template strings, which work in all versions of Node.js that SimpleCrawler supports.

## Rationale

The string formatting currently used when constructing an error in the FS cache backend isn't actually supported in Node.js, and the error that it ultimately emits is not very helpful (i.e. `Cache storage of resource (%s) blocked by file: %s`).