### PR TITLE
Bug fix: Remove fragment (to avoid bad 404s)

### DIFF
--- a/lib/crawler.js
+++ b/lib/crawler.js
@@ -806,7 +806,7 @@ Crawler.prototype.processURL = function(url, referrer) {
     // simplecrawler uses slightly different terminology to URIjs. Sorry!
     return {
         host:      newUrl.hostname(),
-        path:      newUrl.resource(),
+        path:      newUrl.fragment("").resource(),
         port:      newUrl.port(),
         protocol:  newUrl.protocol() || "http",
         uriPath:   newUrl.path(),


### PR DESCRIPTION
Bug fix to remove fragment from the URL, otherwise some servers try to process the fragment (AKA hash) and throw 404 errors instead of opening the intended URL.
